### PR TITLE
Refactor payload error traversal for nested many errors from serializer

### DIFF
--- a/ariadne_extended/contrib/waffle_graph/resolvers.py
+++ b/ariadne_extended/contrib/waffle_graph/resolvers.py
@@ -1,10 +1,9 @@
 from ariadne_extended.resolvers import ListModelResolver, Resolver
-
 from waffle import get_waffle_flag_model
 from waffle.models import Sample, Switch
 from waffle.utils import get_setting
 
-from .types import waffle_item_interface, waffle_type, query
+from .types import query, waffle_item_interface, waffle_type
 
 
 class WaffleResolver(ListModelResolver):

--- a/ariadne_extended/payload/types.py
+++ b/ariadne_extended/payload/types.py
@@ -1,7 +1,8 @@
-from ariadne import ObjectType
+from ariadne import ObjectType, InterfaceType
 
 
 field_error = ObjectType("FieldError")
+payload = InterfaceType("Payload")
 
 
 error_detail = ObjectType("ErrorDetail")

--- a/ariadne_extended/resolvers/abc.py
+++ b/ariadne_extended/resolvers/abc.py
@@ -112,6 +112,11 @@ class Resolver:
 
     @classonlymethod
     def as_nested_resolver(cls, **resolver_config):
+        """
+        When resolving a related type within another type. Performs needed config changes
+        to trigger nested filtering between related objects and select the correct relational field
+        from the orm when used inside a GenericModelResolver
+        """
         resolver_config["nested"] = True
         resolver = cls.as_resolver(**resolver_config)
         return resolver

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1,57 +1,84 @@
 from rest_framework.exceptions import ErrorDetail
 
-from ariadne_extended.payload.resolvers import resolve_field_errors
+from ariadne_extended.payload.resolvers import traverse_errors
 
 
-def test_resolve_field_errors_basic():
-    error_struct = dict(errors=dict(field_one=[ErrorDetail("An error", code=123)]))
+def test_traverse_errors_basic():
+    error_struct = dict(field_one=[ErrorDetail("An error", code=123)])
 
-    result = resolve_field_errors(error_struct, None)
-    assert result == [
+    fields = list()
+    traverse_errors(fields, error_struct, None)
+    assert fields == [
         dict(name="fieldOne", values=[ErrorDetail("An error", code=123)])
     ], "Single fields just include their name"
 
 
-def test_resolve_field_errors_nested():
+def test_traverse_errors_nested():
     nested_error_struct = dict(
-        errors=dict(
-            field_one=[ErrorDetail("An error", code=123)],
-            field_two=dict(nested_field=[ErrorDetail("An error", code=123)]),
-        )
+        field_one=[ErrorDetail("An error", code=123)],
+        field_two=dict(nested_field=[ErrorDetail("An error", code=123)]),
     )
 
-    result = resolve_field_errors(nested_error_struct, None)
-    assert result == [
+    fields = list()
+    traverse_errors(fields, nested_error_struct, None)
+    assert fields == [
         dict(name="fieldOne", values=[ErrorDetail("An error", code=123)]),
         dict(name="fieldTwo.nestedField", values=[ErrorDetail("An error", code=123)]),
     ], "Nested fields use dot lookup notation"
 
 
-def test_resolve_field_errors_nested_index():
+def test_traverse_errors_nested_index():
     nested_index_error_struct = dict(
-        errors=dict(
-            field_one=[ErrorDetail("An error", code=123)],
-            field_two={0: [ErrorDetail("An error", code=123)]},
-        )
+        field_one=[ErrorDetail("An error", code=123)],
+        field_two={0: [ErrorDetail("An error", code=123)]},
     )
 
-    result = resolve_field_errors(nested_index_error_struct, None)
-    assert result == [
+    fields = list()
+    traverse_errors(fields, nested_index_error_struct, None)
+    assert fields == [
         dict(name="fieldOne", values=[ErrorDetail("An error", code=123)]),
         dict(name="fieldTwo[0]", values=[ErrorDetail("An error", code=123)]),
     ], "Indexed errors use array lookup notation"
 
 
-def test_resolve_field_errors_nested_index_object():
+def test_traverse_errors_nested_index_object():
     nested_index_error_object_struct = dict(
-        errors=dict(
-            field_one=[ErrorDetail("An error", code=123)],
-            field_two={0: dict(nested_field=[ErrorDetail("An error", code=123)])},
-        )
+        field_one=[ErrorDetail("An error", code=123)],
+        field_two={0: dict(nested_field=[ErrorDetail("An error", code=123)])},
     )
 
-    result = resolve_field_errors(nested_index_error_object_struct, None)
-    assert result == [
+    fields = list()
+    traverse_errors(fields, nested_index_error_object_struct, None)
+    assert fields == [
         dict(name="fieldOne", values=[ErrorDetail("An error", code=123)]),
         dict(name="fieldTwo[0].nestedField", values=[ErrorDetail("An error", code=123)]),
     ], "Indexed errors can have nested fields"
+
+
+def test_traverse_errors_multiple_nested():
+    nested_indexed_struct = dict(fields=[{}, {}, {"title": [ErrorDetail("An error", code=123)]}])
+    fields = list()
+    traverse_errors(fields, nested_indexed_struct, None)
+    assert fields == [
+        dict(name="fields[2].title", values=[ErrorDetail("An error", code=123)])
+    ], "Nested indexed errors returns one named error"
+
+
+def test_traverse_errors_multiple_nested_further():
+    nested_indexed_struct = dict(
+        fields=[
+            {},
+            {},
+            {
+                "title": [ErrorDetail("An error", code=123)],
+                "options": [{}, {"name": [ErrorDetail("Name required", code=321)]}],
+            },
+        ]
+    )
+
+    fields = list()
+    traverse_errors(fields, nested_indexed_struct, None)
+    assert fields == [
+        dict(name="fields[2].title", values=[ErrorDetail("An error", code=123)]),
+        dict(name="fields[2].options[1].name", values=[ErrorDetail("Name required", code=321)]),
+    ], "Nested indexed errors returns deep indexed errors"


### PR DESCRIPTION
In cases where a nested serializer returns errors, we need to be able to show the index of the nested object the error was generated on and add that to the erroring fields.

Converts the Payload resolver to use an interface field resolver for the errors field instead of the `CustomFieldErrorResolver`.

Tests were modified to point to the new recursive function instead of the resolver, two tests were added to check 2 layers to error nesting for list serializers.